### PR TITLE
used longhand syntax instead of short to fix Radium warning

### DIFF
--- a/packages/typography/src/utils/createStyles.js
+++ b/packages/typography/src/utils/createStyles.js
@@ -91,7 +91,9 @@ module.exports = (vr: any, options: OptionsType) => {
   ], {
 
     // Reset margin/padding to 0.
-    margin: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
     padding: 0,
     marginBottom: blockMarginBottom,
   })


### PR DESCRIPTION
Radium complains when short/longhand syntax are mixed in the same style object.
![screen shot 2016-08-12 at 12 23 44 pm](https://cloud.githubusercontent.com/assets/735565/17611151/07f42040-6088-11e6-87ee-a9c7bcb5489c.png)

