### PR TITLE
Safari is set to wrap text in pre by default

### DIFF
--- a/__test__/__snapshots__/typography-plugin-code.test.js.snap
+++ b/__test__/__snapshots__/typography-plugin-code.test.js.snap
@@ -324,6 +324,7 @@ Object {
     "paddingLeft": 0,
     "paddingRight": 0,
     "paddingTop": 0,
+    "wordWrap": "normal",
   },
   "pre code": Object {
     "background": "none",
@@ -726,6 +727,7 @@ Object {
     "paddingLeft": 0,
     "paddingRight": 0,
     "paddingTop": 0,
+    "wordWrap": "normal",
   },
   "pre code": Object {
     "background": "none",
@@ -1128,6 +1130,7 @@ Object {
     "paddingLeft": 0,
     "paddingRight": 0,
     "paddingTop": 0,
+    "wordWrap": "normal",
   },
   "pre code": Object {
     "background": "none",

--- a/packages/typography-plugin-code/src/index.js
+++ b/packages/typography-plugin-code/src/index.js
@@ -28,6 +28,7 @@ const CodePlugin = (): Function =>
       borderRadius: '3px',
       lineHeight: 1.42,
       overflow: 'auto',
+      wordWrap: 'normal', // So code will scroll on Safari.
       padding: blockMarginBottom,
     },
     'pre code': {


### PR DESCRIPTION
This is annoying for code as code is harder to read when lines are forced to wrap.