### PR TITLE
Fix code coverage badge markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,10 @@ for inline styles.
 
 [build-status]: https://travis-ci.org/KyleAMathews/typography.js
 
+[coverage-status]: https://codecov.io/github/KyleAMathews/typography.js
+
 [coverage-badge]: https://img.shields.io/codecov/c/github/KyleAMathews/typography.js.svg
 
-[coverage-status]: https://codecov.io/github/KyleAMathews/typography.js
 =======
 
 ## Backers


### PR DESCRIPTION
Markdown formatting was breaking for some reason

<img width="735" alt="screen shot 2017-03-24 at 8 47 33 am" src="https://cloud.githubusercontent.com/assets/1832781/24294862/ac73201c-106e-11e7-96b2-90162e3284bd.png">

<img width="854" alt="screen shot 2017-03-24 at 8 47 25 am" src="https://cloud.githubusercontent.com/assets/1832781/24294861/ac6f1224-106e-11e7-860a-031100dd4ec3.png">