### PR TITLE
Use parseInt instead of multiplying by string

### DIFF
--- a/packages/typography/src/index.js
+++ b/packages/typography/src/index.js
@@ -48,7 +48,7 @@ const typography = function(opts: OptionsType) {
     // This doesn't pick the right scale ratio if a theme has more than one ratio.
     // Perhaps add optional parameter for a width and it'll get the ratio
     // for this width. Tricky part is maxWidth could be set in non-pixels.
-    const baseFont = options.baseFontSize.slice(0, -2)
+    const baseFont = parseInt(options.baseFontSize, 10)
     const newFontSize = `${ms(value, options.scaleRatio) * baseFont}px`
     return vr.adjustFontSizeTo(newFontSize)
   }


### PR DESCRIPTION
Currently, we are relying on the fact that multiplying numbers by strings in javascript is apparently perfectly valid...

```javascript
'10' * 10 // 100
```
This upsets flow...

> The operand of an arithmetic operation must be a number.