### PR TITLE
Fix eslint dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "codecov": "^1.0.1",
     "compass-vertical-rhythm": "^1.3.1",
     "eslint": "^3.19.0",
+    "eslint-plugin-flow-vars": "^0.5.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",
     "flow-bin": "^0.45.0",


### PR DESCRIPTION
Add "eslint-plugin-flow-vars" into devDependencies to enable running lint locally.