### PR TITLE
Group selectors with identical styles

### DIFF
--- a/packages/typography/src/client.js
+++ b/packages/typography/src/client.js
@@ -25,7 +25,7 @@ const typography = function(opts: OptionsType) {
       'Helvetica Neue',
       'sans-serif',
     ],
-    bodyFontFamily: ['georgia', 'serif'],
+    bodyFontFamily: ['Georgia', 'serif'],
     headerColor: 'inherit',
     bodyColor: 'hsla(0,0%,0%,0.8)',
     headerWeight: 'bold',

--- a/packages/typography/src/index.js
+++ b/packages/typography/src/index.js
@@ -27,7 +27,7 @@ const typography = function(opts: OptionsType) {
       'Helvetica Neue',
       'sans-serif',
     ],
-    bodyFontFamily: ['georgia', 'serif'],
+    bodyFontFamily: ['Georgia', 'serif'],
     headerColor: 'inherit',
     bodyColor: 'hsla(0,0%,0%,0.8)',
     headerWeight: 'bold',

--- a/packages/typography/src/utils/createStyles.js
+++ b/packages/typography/src/utils/createStyles.js
@@ -83,33 +83,7 @@ module.exports = (vr: any, options: OptionsType) => {
     blockMarginBottom = vr.rhythm(1)
   }
   styles = setStyles(
-    styles,
-    [
-      "h1",
-      "h2",
-      "h3",
-      "h4",
-      "h5",
-      "h6",
-      "hgroup",
-      "ul",
-      "ol",
-      "dl",
-      "dd",
-      "p",
-      "figure",
-      "pre",
-      "table",
-      "fieldset",
-      "blockquote",
-      "form",
-      "noscript",
-      "iframe",
-      "img",
-      "hr",
-      "address",
-    ],
-    {
+    styles, "h1, h2, h3, h4, h5, h6, hgroup, ul, ol, dl, dd, p, figure, pre, table, fieldset, blockquote, form, noscript, iframe, img, hr, address", {
       // Reset margin/padding to 0.
       marginLeft: 0,
       marginRight: 0,
@@ -130,7 +104,7 @@ module.exports = (vr: any, options: OptionsType) => {
   })
 
   // b, strong.
-  styles = setStyles(styles, ["b", "strong", "dt", "th"], {
+  styles = setStyles(styles, "b, strong, dt, th", {
     fontWeight: options.boldWeight,
   })
 
@@ -143,7 +117,7 @@ module.exports = (vr: any, options: OptionsType) => {
   })
 
   // ol, ul.
-  styles = setStyles(styles, ["ol", "ul"], {
+  styles = setStyles(styles, "ol, ul", {
     listStylePosition: "outside",
     listStyleImage: "none",
     marginLeft: vr.rhythm(1),
@@ -155,12 +129,12 @@ module.exports = (vr: any, options: OptionsType) => {
   })
 
   // Remove default padding on list items.
-  styles = setStyles(styles, ["ol li", "ul li"], {
+  styles = setStyles(styles, "ol li, ul li", {
     paddingLeft: 0,
   })
 
   // children ol, ul.
-  styles = setStyles(styles, ["li > ol", "li > ul"], {
+  styles = setStyles(styles, "li > ol, li > ul", {
     marginLeft: vr.rhythm(1),
     marginBottom: `calc(${blockMarginBottom} / 2)`,
     marginTop: `calc(${blockMarginBottom} / 2)`,
@@ -171,7 +145,7 @@ module.exports = (vr: any, options: OptionsType) => {
   // as they put paragraphs within LIs amoung other oddities.
   styles = setStyles(
     styles,
-    ["blockquote *:last-child", "li *:last-child", "p *:last-child"],
+    "blockquote *:last-child, li *:last-child, p *:last-child",
     {
       marginBottom: 0,
     }
@@ -183,12 +157,12 @@ module.exports = (vr: any, options: OptionsType) => {
   })
 
   // Make generally smaller elements, smaller.
-  styles = setStyles(styles, ["code", "kbd", "pre", "samp"], {
+  styles = setStyles(styles, "code, kbd, pre, samp", {
     ...vr.adjustFontSizeTo("85%"),
   })
 
   // Abbr, Acronym.
-  styles = setStyles(styles, ["abbr", "acronym"], {
+  styles = setStyles(styles, "abbr, acronym", {
     borderBottom: `1px dotted ${gray(50)}`,
     cursor: "help",
   })
@@ -199,15 +173,15 @@ module.exports = (vr: any, options: OptionsType) => {
   }
 
   // Table styles.
-  styles = setStyles(styles, ["table"], {
+  styles = setStyles(styles, "table", {
     ...vr.adjustFontSizeTo(options.baseFontSize),
     borderCollapse: "collapse",
     width: "100%",
   })
-  styles = setStyles(styles, ["thead"], {
+  styles = setStyles(styles, "thead", {
     textAlign: "left",
   })
-  styles = setStyles(styles, ["td,th"], {
+  styles = setStyles(styles, "td, th", {
     textAlign: "left",
     borderBottom: `1px solid ${gray(88)}`,
     fontFeatureSettings: '"tnum"',
@@ -227,7 +201,7 @@ module.exports = (vr: any, options: OptionsType) => {
   })
 
   // Create styles for headers.
-  styles = setStyles(styles, ["h1", "h2", "h3", "h4", "h5", "h6"], {
+  styles = setStyles(styles, "h1, h2, h3, h4, h5, h6", {
     color: options.headerColor,
     fontFamily: options.headerFontFamily.map(wrapFontFamily).join(","),
     fontWeight: options.headerWeight,


### PR DESCRIPTION
Replaces selector arrays, e.g. `["b", "strong", "dt", "th"]` with strings, e.g. `"b, strong, dt, th"` for more compact CSS output. Also fixes a typo (`"Georgia"`).