### PR TITLE
fixes broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ NPM](https://www.npmjs.com/browse/keyword/typography-theme).
 ## Sites that use Typography.js
 * [bricolage.io](https://bricolage.io/?utm_source=github.com) ([source](https://github.com/KyleAMathews/blog/blob/master/blog-typography.coffee))
 * [React Headroom](https://kyleamathews.github.io/react-headroom/) ([source](https://github.com/KyleAMathews/react-headroom/blob/master/www/utils/typography.js))
-* [Gatsby Blog Starter](http://gatsbyjs.github.io/gatsby-starter-blog/) ([source](https://github.com/gatsbyjs/gatsby-starter-blog/blob/master/utils/typography.js))
+* [Gatsby Blog Starter](http://gatsbyjs.github.io/gatsby-starter-blog/) ([source](https://github.com/gatsbyjs/gatsby-starter-blog/blob/master/src/utils/typography.js))
 * [ollieglass.com](http://ollieglass.com/)
 * [markOnSoftware](https://markjoelchavez.com)
 * [Edit this file to add yours!](https://github.com/KyleAMathews/typography.js/blob/master/README.md)


### PR DESCRIPTION
In section `Sites that use Typography.js` link for source of Gatsby_Blog_Starter