### PR TITLE
Fix sans-serif body font fallbacks for fairy-gates and wordpress-2013

### DIFF
--- a/__test__/__snapshots__/typography-themes.test.js.snap
+++ b/__test__/__snapshots__/typography-themes.test.js.snap
@@ -2263,7 +2263,7 @@ Object {
     "MozFontFeatureSettings": "\\"kern\\", \\"liga\\", \\"clig\\", \\"calt\\"",
     "WebkitFontFeatureSettings": "\\"kern\\", \\"liga\\", \\"clig\\", \\"calt\\"",
     "color": "hsla(0,0%,0%,0.8)",
-    "fontFamily": "'Quattrocento Sans',serif",
+    "fontFamily": "'Quattrocento Sans',sans-serif",
     "fontFeatureSettings": "\\"kern\\", \\"liga\\", \\"clig\\", \\"calt\\"",
     "fontKerning": "normal",
     "fontWeight": 400,
@@ -2452,7 +2452,7 @@ Object {
   },
   "html": Object {
     "boxSizing": "border-box",
-    "font": "125%/1.45 'Quattrocento Sans',serif",
+    "font": "125%/1.45 'Quattrocento Sans',sans-serif",
     "overflowY": "scroll",
   },
   "iframe": Object {
@@ -12936,7 +12936,7 @@ Object {
     "MozFontFeatureSettings": "\\"kern\\", \\"liga\\", \\"clig\\", \\"calt\\"",
     "WebkitFontFeatureSettings": "\\"kern\\", \\"liga\\", \\"clig\\", \\"calt\\"",
     "color": "hsla(0,0%,0%,0.93)",
-    "fontFamily": "'Source Sans Pro',serif",
+    "fontFamily": "'Source Sans Pro',sans-serif",
     "fontFeatureSettings": "\\"kern\\", \\"liga\\", \\"clig\\", \\"calt\\"",
     "fontKerning": "normal",
     "fontWeight": 400,
@@ -13121,7 +13121,7 @@ Object {
   },
   "html": Object {
     "boxSizing": "border-box",
-    "font": "100%/1.5 'Source Sans Pro',serif",
+    "font": "100%/1.5 'Source Sans Pro',sans-serif",
     "overflowY": "scroll",
   },
   "iframe": Object {

--- a/packages/typography-theme-fairy-gates/src/index.js
+++ b/packages/typography-theme-fairy-gates/src/index.js
@@ -19,7 +19,7 @@ const theme: OptionsType = {
     },
   ],
   headerFontFamily: ['Work Sans', 'sans-serif'],
-  bodyFontFamily: ['Quattrocento Sans', 'serif'],
+  bodyFontFamily: ['Quattrocento Sans', 'sans-serif'],
   headerColor: 'hsla(0,0%,0%,0.9)',
   bodyColor: 'hsla(0,0%,0%,0.8)',
   headerWeight: '600',

--- a/packages/typography-theme-wordpress-2013/src/index.js
+++ b/packages/typography-theme-wordpress-2013/src/index.js
@@ -17,7 +17,7 @@ const theme: OptionsType = {
     },
   ],
   headerFontFamily: ['Bitter', 'serif'],
-  bodyFontFamily: ['Source Sans Pro', 'serif'],
+  bodyFontFamily: ['Source Sans Pro', 'sans-serif'],
   bodyColor: 'hsla(0,0%,0%,0.93)',
   headerWeight: '700',
   bodyWeight: 400,


### PR DESCRIPTION
Fixes #174 and also fixes the same for Wordpress 2013.

Let me know if any other changes are required.