### PR TITLE
fix(typography): Prepend styles to <head> instead of placing them at end, possibly overwriting user styles

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "endOfLine": "lf",
+  "semi": false,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/__test__/typography.test.js
+++ b/__test__/typography.test.js
@@ -1,13 +1,13 @@
 // @flow
 
-import typography from '../packages/typography/src/index'
+import typography from "../packages/typography/src/index"
 
-describe('typography(options?)', () => {
-  it('should be a function', () => {
+describe("typography(options?)", () => {
+  it("should be a function", () => {
     expect(typography).toEqual(jasmine.any(Function))
   })
 
-  it('should return a structure', () => {
+  it("should return a structure", () => {
     const actual = typography()
     expect(actual.options).toEqual(jasmine.any(Object))
     expect(actual.rhythm).toEqual(jasmine.any(Function))
@@ -22,34 +22,34 @@ describe('typography(options?)', () => {
   })
 })
 
-describe('typography(options?).scale()', () => {
-  it('should scale', () => {
+describe("typography(options?).scale()", () => {
+  it("should scale", () => {
     const actual = typography().scale()
-    expect(actual.fontSize).toEqual('1rem')
-    expect(actual.lineHeight).toEqual('1.45rem')
+    expect(actual.fontSize).toEqual("1rem")
+    expect(actual.lineHeight).toEqual("1.45rem")
   })
 
-  it('should accept custom scales', () => {
+  it("should accept custom scales", () => {
     const actual = typography().scale(1.333)
-    expect(actual.fontSize).toEqual('2.51926rem')
-    expect(actual.lineHeight).toEqual('2.9rem')
+    expect(actual.fontSize).toEqual("2.51926rem")
+    expect(actual.lineHeight).toEqual("2.9rem")
   })
 
-  it('should accept custom scales', () => {
+  it("should accept custom scales", () => {
     const actual = typography().scale(2)
-    expect(actual.fontSize).toEqual('4rem')
-    expect(actual.lineHeight).toEqual('4.35rem')
+    expect(actual.fontSize).toEqual("4rem")
+    expect(actual.lineHeight).toEqual("4.35rem")
   })
 })
 
-describe('typography(options?).toJSON()', () => {
-  it('should return CSS as JSON', () => {
+describe("typography(options?).toJSON()", () => {
+  it("should return CSS as JSON", () => {
     expect(typography().toJSON()).toMatchSnapshot()
   })
 })
 
-describe('typography(options?).toString()', () => {
-  it('should return CSS as a string', () => {
+describe("typography(options?).toString()", () => {
+  it("should return CSS as a string", () => {
     expect(
       typography({
         includeNormalize: false,
@@ -58,8 +58,8 @@ describe('typography(options?).toString()', () => {
   })
 })
 
-describe('typography(options?).createStyles()', () => {
-  it('should return CSS as a string', () => {
+describe("typography(options?).createStyles()", () => {
+  it("should return CSS as a string", () => {
     expect(
       typography({
         includeNormalize: false,
@@ -68,21 +68,21 @@ describe('typography(options?).createStyles()', () => {
   })
 })
 
-describe('typography(options?).injectStyles()', () => {
+describe("typography(options?).injectStyles()", () => {
   beforeEach(() => {
     delete global.document
   })
 
-  it('should not fail if document is undefined', () => {
+  it("should not fail if document is undefined", () => {
     expect(() => {
       typography().injectStyles()
     }).not.toThrow()
   })
 
-  it('should set style if typography.js element exists', () => {
+  it("should set style if typography.js element exists", () => {
     const sut = typography()
 
-    global.document = jasmine.createSpyObj('document', ['getElementById'])
+    global.document = jasmine.createSpyObj("document", ["getElementById"])
 
     const styleNode = {}
 
@@ -91,41 +91,41 @@ describe('typography(options?).injectStyles()', () => {
     sut.injectStyles()
 
     expect(styleNode.innerHTML).toEqual(sut.toString())
-    expect(global.document.getElementById).toHaveBeenCalledWith('typography.js')
+    expect(global.document.getElementById).toHaveBeenCalledWith("typography.js")
   })
 
-  it('should create a new style node if typography.js element does not exists', () => {
+  it("should create a new style node if typography.js element does not exists", () => {
     const sut = typography()
 
-    global.document = jasmine.createSpyObj('document', [
-      'head',
-      'createElement',
-      'getElementById',
+    global.document = jasmine.createSpyObj("document", [
+      "head",
+      "createElement",
+      "getElementById",
     ])
 
     const styleNode = {}
 
     global.document.getElementById.and.returnValue(null)
     global.document.createElement.and.returnValue(styleNode)
-    global.document.head.appendChild = jasmine.createSpy('appendChild')
+    global.document.head.prepend = jasmine.createSpy("prepend")
 
     sut.injectStyles()
 
-    expect(styleNode.id).toEqual('typography.js')
+    expect(styleNode.id).toEqual("typography.js")
     expect(styleNode.innerHTML).toEqual(sut.toString())
-    expect(global.document.createElement).toHaveBeenCalledWith('style')
-    expect(global.document.getElementById).toHaveBeenCalledWith('typography.js')
-    expect(global.document.head.appendChild).toHaveBeenCalledWith(styleNode)
+    expect(global.document.createElement).toHaveBeenCalledWith("style")
+    expect(global.document.getElementById).toHaveBeenCalledWith("typography.js")
+    expect(global.document.head.prepend).toHaveBeenCalledWith(styleNode)
   })
 
-  describe('prepending', () => {
+  describe("prepending", () => {
     const setup = (styleNode, head) => {
       const sut = typography()
 
-      global.document = jasmine.createSpyObj('document', [
-        'head',
-        'createElement',
-        'getElementById',
+      global.document = jasmine.createSpyObj("document", [
+        "head",
+        "createElement",
+        "getElementById",
       ])
 
       global.document.getElementById.and.returnValue(null)
@@ -135,26 +135,13 @@ describe('typography(options?).injectStyles()', () => {
       sut.injectStyles(true)
     }
 
-    it('can add to beginning of head tags', () => {
+    it("can add to beginning of head tags", () => {
       const styleNode = {}
       const head = {
-        insertBefore: jasmine.createSpy(),
-        firstChild: {},
+        prepend: jasmine.createSpy(),
       }
       setup(styleNode, head)
-      expect(head.insertBefore).toHaveBeenCalledWith(styleNode, head.firstChild)
-    })
-
-    it('uses appendChild if head tags are empty', () => {
-      const styleNode = {}
-      const head = {
-        appendChild: jasmine.createSpy(),
-        firstChild: null,
-      }
-
-      setup(styleNode, head)
-
-      expect(head.appendChild).toHaveBeenCalledWith(styleNode)
+      expect(head.prepend).toHaveBeenCalledWith(styleNode)
     })
   })
 })

--- a/__test__/typography.test.js
+++ b/__test__/typography.test.js
@@ -1,13 +1,13 @@
 // @flow
 
-import typography from "../packages/typography/src/index"
+import typography from '../packages/typography/src/index'
 
-describe("typography(options?)", () => {
-  it("should be a function", () => {
+describe('typography(options?)', () => {
+  it('should be a function', () => {
     expect(typography).toEqual(jasmine.any(Function))
   })
 
-  it("should return a structure", () => {
+  it('should return a structure', () => {
     const actual = typography()
     expect(actual.options).toEqual(jasmine.any(Object))
     expect(actual.rhythm).toEqual(jasmine.any(Function))
@@ -22,34 +22,34 @@ describe("typography(options?)", () => {
   })
 })
 
-describe("typography(options?).scale()", () => {
-  it("should scale", () => {
+describe('typography(options?).scale()', () => {
+  it('should scale', () => {
     const actual = typography().scale()
-    expect(actual.fontSize).toEqual("1rem")
-    expect(actual.lineHeight).toEqual("1.45rem")
+    expect(actual.fontSize).toEqual('1rem')
+    expect(actual.lineHeight).toEqual('1.45rem')
   })
 
-  it("should accept custom scales", () => {
+  it('should accept custom scales', () => {
     const actual = typography().scale(1.333)
-    expect(actual.fontSize).toEqual("2.51926rem")
-    expect(actual.lineHeight).toEqual("2.9rem")
+    expect(actual.fontSize).toEqual('2.51926rem')
+    expect(actual.lineHeight).toEqual('2.9rem')
   })
 
-  it("should accept custom scales", () => {
+  it('should accept custom scales', () => {
     const actual = typography().scale(2)
-    expect(actual.fontSize).toEqual("4rem")
-    expect(actual.lineHeight).toEqual("4.35rem")
+    expect(actual.fontSize).toEqual('4rem')
+    expect(actual.lineHeight).toEqual('4.35rem')
   })
 })
 
-describe("typography(options?).toJSON()", () => {
-  it("should return CSS as JSON", () => {
+describe('typography(options?).toJSON()', () => {
+  it('should return CSS as JSON', () => {
     expect(typography().toJSON()).toMatchSnapshot()
   })
 })
 
-describe("typography(options?).toString()", () => {
-  it("should return CSS as a string", () => {
+describe('typography(options?).toString()', () => {
+  it('should return CSS as a string', () => {
     expect(
       typography({
         includeNormalize: false,
@@ -58,8 +58,8 @@ describe("typography(options?).toString()", () => {
   })
 })
 
-describe("typography(options?).createStyles()", () => {
-  it("should return CSS as a string", () => {
+describe('typography(options?).createStyles()', () => {
+  it('should return CSS as a string', () => {
     expect(
       typography({
         includeNormalize: false,
@@ -68,21 +68,21 @@ describe("typography(options?).createStyles()", () => {
   })
 })
 
-describe("typography(options?).injectStyles()", () => {
+describe('typography(options?).injectStyles()', () => {
   beforeEach(() => {
     delete global.document
   })
 
-  it("should not fail if document is undefined", () => {
+  it('should not fail if document is undefined', () => {
     expect(() => {
       typography().injectStyles()
     }).not.toThrow()
   })
 
-  it("should set style if typography.js element exists", () => {
+  it('should set style if typography.js element exists', () => {
     const sut = typography()
 
-    global.document = jasmine.createSpyObj("document", ["getElementById"])
+    global.document = jasmine.createSpyObj('document', ['getElementById'])
 
     const styleNode = {}
 
@@ -91,69 +91,69 @@ describe("typography(options?).injectStyles()", () => {
     sut.injectStyles()
 
     expect(styleNode.innerHTML).toEqual(sut.toString())
-    expect(global.document.getElementById).toHaveBeenCalledWith("typography.js")
+    expect(global.document.getElementById).toHaveBeenCalledWith('typography.js')
   })
 
-  it("should create a new style node if typography.js element does not exists", () => {
+  it('should create a new style node if typography.js element does not exists', () => {
     const sut = typography()
 
-    global.document = jasmine.createSpyObj("document", [
-      "head",
-      "createElement",
-      "getElementById",
+    global.document = jasmine.createSpyObj('document', [
+      'head',
+      'createElement',
+      'getElementById',
     ])
 
     const styleNode = {}
 
     global.document.getElementById.and.returnValue(null)
     global.document.createElement.and.returnValue(styleNode)
-    global.document.head.appendChild = jasmine.createSpy("appendChild")
+    global.document.head.appendChild = jasmine.createSpy('appendChild')
 
     sut.injectStyles()
 
-    expect(styleNode.id).toEqual("typography.js")
+    expect(styleNode.id).toEqual('typography.js')
     expect(styleNode.innerHTML).toEqual(sut.toString())
-    expect(global.document.createElement).toHaveBeenCalledWith("style")
-    expect(global.document.getElementById).toHaveBeenCalledWith("typography.js")
+    expect(global.document.createElement).toHaveBeenCalledWith('style')
+    expect(global.document.getElementById).toHaveBeenCalledWith('typography.js')
     expect(global.document.head.appendChild).toHaveBeenCalledWith(styleNode)
   })
 
-  describe("prepending", () => {
+  describe('prepending', () => {
     const setup = (styleNode, head) => {
       const sut = typography()
-  
-      global.document = jasmine.createSpyObj("document", [
-        "head",
-        "createElement",
-        "getElementById",
+
+      global.document = jasmine.createSpyObj('document', [
+        'head',
+        'createElement',
+        'getElementById',
       ])
-  
+
       global.document.getElementById.and.returnValue(null)
       global.document.createElement.and.returnValue(styleNode)
       global.document.head = head
-  
+
       sut.injectStyles(true)
     }
-  
-    it("can add to beginning of head tags", () => {
+
+    it('can add to beginning of head tags', () => {
       const styleNode = {}
       const head = {
         insertBefore: jasmine.createSpy(),
-        firstChild: {}
+        firstChild: {},
       }
       setup(styleNode, head)
       expect(head.insertBefore).toHaveBeenCalledWith(styleNode, head.firstChild)
     })
 
-    it("uses appendChild if head tags are empty", () => {
+    it('uses appendChild if head tags are empty', () => {
       const styleNode = {}
       const head = {
         appendChild: jasmine.createSpy(),
-        firstChild: null
+        firstChild: null,
       }
 
       setup(styleNode, head)
-  
+
       expect(head.appendChild).toHaveBeenCalledWith(styleNode)
     })
   })

--- a/__test__/typography.test.js
+++ b/__test__/typography.test.js
@@ -69,13 +69,17 @@ describe("typography(options?).createStyles()", () => {
 })
 
 describe("typography(options?).injectStyles()", () => {
+  beforeEach(() => {
+    delete global.document
+  })
+
   it("should not fail if document is undefined", () => {
     expect(() => {
       typography().injectStyles()
     }).not.toThrow()
   })
 
-  it("should set css if typography.js element exists", () => {
+  it("should set style if typography.js element exists", () => {
     const sut = typography()
 
     global.document = jasmine.createSpyObj("document", ["getElementById"])
@@ -88,8 +92,6 @@ describe("typography(options?).injectStyles()", () => {
 
     expect(styleNode.innerHTML).toEqual(sut.toString())
     expect(global.document.getElementById).toHaveBeenCalledWith("typography.js")
-
-    delete global.document
   })
 
   it("should create a new style node if typography.js element does not exists", () => {
@@ -114,7 +116,53 @@ describe("typography(options?).injectStyles()", () => {
     expect(global.document.createElement).toHaveBeenCalledWith("style")
     expect(global.document.getElementById).toHaveBeenCalledWith("typography.js")
     expect(global.document.head.appendChild).toHaveBeenCalledWith(styleNode)
+  })
 
-    delete global.document
+  describe("prepending", () => {
+    it("can add to beginning of head tags", () => {
+      const sut = typography()
+  
+      global.document = jasmine.createSpyObj("document", [
+        "head",
+        "createElement",
+        "getElementById",
+      ])
+  
+      const styleNode = {}
+  
+      global.document.getElementById.and.returnValue(null)
+      global.document.createElement.and.returnValue(styleNode)
+      global.document.head = {
+        insertBefore: jasmine.createSpy(),
+        firstChild: {}
+      }
+  
+      sut.injectStyles(true)
+  
+      expect(global.document.head.insertBefore).toHaveBeenCalledWith(styleNode, global.document.head.firstChild)
+    })
+
+    it("uses appendChild if head tags are empty", () => {
+      const sut = typography()
+  
+      global.document = jasmine.createSpyObj("document", [
+        "head",
+        "createElement",
+        "getElementById",
+      ])
+  
+      const styleNode = {}
+  
+      global.document.getElementById.and.returnValue(null)
+      global.document.createElement.and.returnValue(styleNode)
+      global.document.head = {
+        appendChild: jasmine.createSpy(),
+        firstChild: null
+      }
+  
+      sut.injectStyles(true)
+  
+      expect(global.document.head.appendChild).toHaveBeenCalledWith(styleNode)
+    })
   })
 })

--- a/__test__/typography.test.js
+++ b/__test__/typography.test.js
@@ -119,7 +119,7 @@ describe("typography(options?).injectStyles()", () => {
   })
 
   describe("prepending", () => {
-    it("can add to beginning of head tags", () => {
+    const setup = (styleNode, head) => {
       const sut = typography()
   
       global.document = jasmine.createSpyObj("document", [
@@ -128,41 +128,33 @@ describe("typography(options?).injectStyles()", () => {
         "getElementById",
       ])
   
-      const styleNode = {}
-  
       global.document.getElementById.and.returnValue(null)
       global.document.createElement.and.returnValue(styleNode)
-      global.document.head = {
+      global.document.head = head
+  
+      sut.injectStyles(true)
+    }
+  
+    it("can add to beginning of head tags", () => {
+      const styleNode = {}
+      const head = {
         insertBefore: jasmine.createSpy(),
         firstChild: {}
       }
-  
-      sut.injectStyles(true)
-  
-      expect(global.document.head.insertBefore).toHaveBeenCalledWith(styleNode, global.document.head.firstChild)
+      setup(styleNode, head)
+      expect(head.insertBefore).toHaveBeenCalledWith(styleNode, head.firstChild)
     })
 
     it("uses appendChild if head tags are empty", () => {
-      const sut = typography()
-  
-      global.document = jasmine.createSpyObj("document", [
-        "head",
-        "createElement",
-        "getElementById",
-      ])
-  
       const styleNode = {}
-  
-      global.document.getElementById.and.returnValue(null)
-      global.document.createElement.and.returnValue(styleNode)
-      global.document.head = {
+      const head = {
         appendChild: jasmine.createSpy(),
         firstChild: null
       }
+
+      setup(styleNode, head)
   
-      sut.injectStyles(true)
-  
-      expect(global.document.head.appendChild).toHaveBeenCalledWith(styleNode)
+      expect(head.appendChild).toHaveBeenCalledWith(styleNode)
     })
   })
 })

--- a/packages/typography/src/index.js
+++ b/packages/typography/src/index.js
@@ -1,40 +1,40 @@
 // @flow
-import objectAssign from 'object-assign'
-import verticalRhythm from 'compass-vertical-rhythm'
-import ms from 'modularscale'
+import objectAssign from "object-assign"
+import verticalRhythm from "compass-vertical-rhythm"
+import ms from "modularscale"
 
-import createStyles from './utils/createStyles'
-import compileStyles from './utils/compileStyles'
-import type { OptionsType } from 'Types'
+import createStyles from "./utils/createStyles"
+import compileStyles from "./utils/compileStyles"
+import type { OptionsType } from "Types"
 
 const typography = function(opts: OptionsType) {
   const defaults: OptionsType = {
-    baseFontSize: '16px',
+    baseFontSize: "16px",
     baseLineHeight: 1.45,
     headerLineHeight: 1.1,
     scaleRatio: 2,
     googleFonts: [],
     headerFontFamily: [
-      '-apple-system',
-      'BlinkMacSystemFont',
-      'Segoe UI',
-      'Roboto',
-      'Oxygen',
-      'Ubuntu',
-      'Cantarell',
-      'Fira Sans',
-      'Droid Sans',
-      'Helvetica Neue',
-      'sans-serif',
+      "-apple-system",
+      "BlinkMacSystemFont",
+      "Segoe UI",
+      "Roboto",
+      "Oxygen",
+      "Ubuntu",
+      "Cantarell",
+      "Fira Sans",
+      "Droid Sans",
+      "Helvetica Neue",
+      "sans-serif"
     ],
-    bodyFontFamily: ['georgia', 'serif'],
-    headerColor: 'inherit',
-    bodyColor: 'hsla(0,0%,0%,0.8)',
-    headerWeight: 'bold',
-    bodyWeight: 'normal',
-    boldWeight: 'bold',
+    bodyFontFamily: ["georgia", "serif"],
+    headerColor: "inherit",
+    bodyColor: "hsla(0,0%,0%,0.8)",
+    headerWeight: "bold",
+    bodyWeight: "normal",
+    boldWeight: "bold",
     includeNormalize: true,
-    blockMarginBottom: 1,
+    blockMarginBottom: 1
   }
 
   const options = objectAssign({}, defaults, opts)
@@ -65,25 +65,20 @@ const typography = function(opts: OptionsType) {
     toString() {
       return compileStyles(vr, options, this.toJSON())
     },
-    injectStyles(prepend = false) {
-      if (typeof document !== 'undefined') {
+    injectStyles() {
+      if (typeof document !== "undefined") {
         // Replace existing
-        if (document.getElementById('typography.js')) {
-          const styleNode = document.getElementById('typography.js')
+        if (document.getElementById("typography.js")) {
+          const styleNode = document.getElementById("typography.js")
           styleNode.innerHTML = this.toString()
         } else {
-          const node = document.createElement('style')
-          node.id = 'typography.js'
+          const node = document.createElement("style")
+          node.id = "typography.js"
           node.innerHTML = this.toString()
-          const head = document.head
-          if (prepend && head.firstChild) {
-            head.insertBefore(node, head.firstChild)
-          } else {
-            head.appendChild(node)
-          }
+          document.head.prepend(node)
         }
       }
-    },
+    }
   }
 }
 

--- a/packages/typography/src/index.js
+++ b/packages/typography/src/index.js
@@ -65,7 +65,7 @@ const typography = function(opts: OptionsType) {
     toString() {
       return compileStyles(vr, options, this.toJSON())
     },
-    injectStyles() {
+    injectStyles(prepend = false) {
       if (typeof document !== "undefined") {
         // Replace existing
         if (document.getElementById("typography.js")) {
@@ -75,7 +75,12 @@ const typography = function(opts: OptionsType) {
           const node = document.createElement("style")
           node.id = "typography.js"
           node.innerHTML = this.toString()
-          document.head.appendChild(node)
+          const head = document.head
+          if (prepend && head.firstChild) {
+            head.insertBefore(node, head.firstChild)
+          } else {
+            head.appendChild(node)
+          }
         }
       }
     },

--- a/packages/typography/src/index.js
+++ b/packages/typography/src/index.js
@@ -1,38 +1,38 @@
 // @flow
-import objectAssign from "object-assign"
-import verticalRhythm from "compass-vertical-rhythm"
-import ms from "modularscale"
+import objectAssign from 'object-assign'
+import verticalRhythm from 'compass-vertical-rhythm'
+import ms from 'modularscale'
 
-import createStyles from "./utils/createStyles"
-import compileStyles from "./utils/compileStyles"
-import type { OptionsType } from "Types"
+import createStyles from './utils/createStyles'
+import compileStyles from './utils/compileStyles'
+import type { OptionsType } from 'Types'
 
 const typography = function(opts: OptionsType) {
   const defaults: OptionsType = {
-    baseFontSize: "16px",
+    baseFontSize: '16px',
     baseLineHeight: 1.45,
     headerLineHeight: 1.1,
     scaleRatio: 2,
     googleFonts: [],
     headerFontFamily: [
-      "-apple-system",
-      "BlinkMacSystemFont",
-      "Segoe UI",
-      "Roboto",
-      "Oxygen",
-      "Ubuntu",
-      "Cantarell",
-      "Fira Sans",
-      "Droid Sans",
-      "Helvetica Neue",
-      "sans-serif",
+      '-apple-system',
+      'BlinkMacSystemFont',
+      'Segoe UI',
+      'Roboto',
+      'Oxygen',
+      'Ubuntu',
+      'Cantarell',
+      'Fira Sans',
+      'Droid Sans',
+      'Helvetica Neue',
+      'sans-serif',
     ],
-    bodyFontFamily: ["georgia", "serif"],
-    headerColor: "inherit",
-    bodyColor: "hsla(0,0%,0%,0.8)",
-    headerWeight: "bold",
-    bodyWeight: "normal",
-    boldWeight: "bold",
+    bodyFontFamily: ['georgia', 'serif'],
+    headerColor: 'inherit',
+    bodyColor: 'hsla(0,0%,0%,0.8)',
+    headerWeight: 'bold',
+    bodyWeight: 'normal',
+    boldWeight: 'bold',
     includeNormalize: true,
     blockMarginBottom: 1,
   }
@@ -66,14 +66,14 @@ const typography = function(opts: OptionsType) {
       return compileStyles(vr, options, this.toJSON())
     },
     injectStyles(prepend = false) {
-      if (typeof document !== "undefined") {
+      if (typeof document !== 'undefined') {
         // Replace existing
-        if (document.getElementById("typography.js")) {
-          const styleNode = document.getElementById("typography.js")
+        if (document.getElementById('typography.js')) {
+          const styleNode = document.getElementById('typography.js')
           styleNode.innerHTML = this.toString()
         } else {
-          const node = document.createElement("style")
-          node.id = "typography.js"
+          const node = document.createElement('style')
+          node.id = 'typography.js'
           node.innerHTML = this.toString()
           const head = document.head
           if (prepend && head.firstChild) {


### PR DESCRIPTION
Adds the ability to prepend with injectStyles.

I made this opt-in (with a boolean) so that the existing behavior will remain, unless explicitly tweaked. That being said--this seems like a fix for confusing behavior, so I'd be happy to make this the default if we're comfortable with potential breaking changes.