### PR TITLE
Call overrideThemeStyles on the imported theme

### DIFF
--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -103,7 +103,7 @@ styles on a theme:
 ```javascript
 import Typography from 'typography'
 import funstonTheme from 'typography-theme-funston'
-funston.overrideThemeStyles = ({ rhythm }, options) => ({
+funstonTheme.overrideThemeStyles = ({ rhythm }, options) => ({
   'h2,h3': {
     marginBottom: rhythm(1/2),
     marginTop: rhythm(2),


### PR DESCRIPTION
Fixes a typo on the typography readme.