### PR TITLE
211 support font display for googlefonts

### DIFF
--- a/__test__/__snapshots__/react-typography.test.js.snap
+++ b/__test__/__snapshots__/react-typography.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`GoogleFont should render with googleFonts options 1`] = `
 <link
-  href="//fonts.googleapis.com/css?family=Montserrat:700"
+  href="//fonts.googleapis.com/css?family=Montserrat:700&display=optional"
   rel="stylesheet"
   type="text/css"
 />

--- a/__test__/react-typography.test.js
+++ b/__test__/react-typography.test.js
@@ -23,13 +23,13 @@ describe('GoogleFont', () => {
   it('should render with googleFonts options', () => {
     const component = renderer.create(React.createElement(GoogleFont, {
       typography: typography({
+        fontDisplay: 'optional',
         googleFonts: [
           {
             name: 'Montserrat',
             styles: [
               '700',
             ],
-            display: 'optional'
           },
         ],
       }),

--- a/__test__/react-typography.test.js
+++ b/__test__/react-typography.test.js
@@ -29,6 +29,7 @@ describe('GoogleFont', () => {
             styles: [
               '700',
             ],
+            display: 'optional'
           },
         ],
       }),

--- a/packages/react-typography/src/GoogleFont.js
+++ b/packages/react-typography/src/GoogleFont.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types"
 
 const GoogleFont = props => {
   // Create family + styles string
-  const validFontDisplayTypes = ['block', 'swap', 'fallback', 'optional']
   let fontsStr = ""
   if (props.typography.options.googleFonts) {
     const fonts = props.typography.options.googleFonts.map(font => {
@@ -12,19 +11,20 @@ const GoogleFont = props => {
       str += ":"
       str += font.styles.join(",")
 
-      let fontDisplay = 'swap'
-      if (font.display && validFontDisplayTypes.includes(font.display)) {
-        fontDisplay = font.display
-      }
-
-      str += `&display=${fontDisplay}`
-
       return str
     })
 
     fontsStr = fonts.join("|")
 
     if (fontsStr) {
+      let fontDisplay = 'swap'
+      let validFontDisplayTypes = ['block', 'swap', 'fallback', 'optional']
+      if (props.typography.options.fontDisplay && validFontDisplayTypes.includes(props.typography.options.fontDisplay)) {
+        fontDisplay = props.typography.options.fontDisplay
+      }
+
+      fontsStr += `&display=${fontDisplay}`
+
       return (
         <link
           href={`//fonts.googleapis.com/css?family=${fontsStr}`}

--- a/packages/react-typography/src/GoogleFont.js
+++ b/packages/react-typography/src/GoogleFont.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types"
 
 const GoogleFont = props => {
   // Create family + styles string
+  const validFontDisplayTypes = ['block', 'swap', 'fallback', 'optional']
   let fontsStr = ""
   if (props.typography.options.googleFonts) {
     const fonts = props.typography.options.googleFonts.map(font => {
@@ -10,6 +11,13 @@ const GoogleFont = props => {
       str += font.name.split(" ").join("+")
       str += ":"
       str += font.styles.join(",")
+
+      let fontDisplay = 'swap'
+      if (font.display && validFontDisplayTypes.includes(font.display)) {
+        fontDisplay = font.display
+      }
+
+      str += `&display=${fontDisplay}`
 
       return str
     })


### PR DESCRIPTION
This PR adds a `fontDisplay` option to the options object that can be used to add `font-display` to google fonts imports.

Resolves #211