### PR TITLE
Add Domo Arigato theme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '6'
   - '8'
 sudo: false
 before_script:

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ const typography = new Typography(funstonTheme)
 * [typography-theme-trajan](https://github.com/guoliim/typography-theme-trajan)
 * [typography-theme-zacklive](https://github.com/ZacharyChim/typography-theme-zacklive)
 * [typography-theme-anonymous](https://github.com/leimonio/typography-theme-anonymous)
+* [typography-theme-domo-arigato](https://github.com/aalaap/typography-theme-domo-arigato) - A theme with Roboto fonts
 * If you publish your own, create a PR to add it here!
 
 ## Plugins


### PR DESCRIPTION
This adds links and info about the Domo Arigato theme, which uses Roboto fonts and is based on the US Web Design Standards theme.

_Note:_ I've seen other PRs fail recently, so @KyleAMathews you might want to take a look.

Thank you!