### PR TITLE
docs(readme): remove redundant heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# Typography.js
-A powerful toolkit for building websites with beautiful typography.
 # Typography.js [![Build Status][build-badge]][build-status] [![Coverage Status][coverage-badge]][coverage-status]
-A powerful toolkit for building websites with beautiful design.
+A powerful toolkit for building websites with beautiful typography.
 
 ## Install
 `npm install typography`

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -1,7 +1,5 @@
-# Typography.js
-A powerful toolkit for building websites with beautiful typography.
 # Typography.js [![Build Status][build-badge]][build-status] [![Coverage Status][coverage-badge]][coverage-status]
-A powerful toolkit for building websites with beautiful design.
+A powerful toolkit for building websites with beautiful typography.
 
 ## Install
 `npm install typography`


### PR DESCRIPTION
Looks like the README has a redundant heading. Was this intentional for some reason?

Which subheading do we prefer? I went with 1 for now.

1. `A powerful toolkit for building websites with beautiful typography.`
2. `A powerful toolkit for building websites with beautiful design.`
