### PR TITLE
Clarify overrideThemeStyles function

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ funstonTheme.overrideThemeStyles = ({ rhythm }, options) => ({
 const typography = new Typography(funstonTheme)
 ```
 
+`overrideThemeStyles` is a function that returns an object where keys are CSS selectors, and values are CSSOM rule sets.
+
 ### Published Typography.js Themes
 * [typography-theme-alton](https://github.com/KyleAMathews/typography.js/blob/master/packages/typography-theme-alton/)
 * [typography-theme-bootstrap](https://github.com/KyleAMathews/typography.js/blob/master/packages/typography-theme-bootstrap/)


### PR DESCRIPTION
I was a bit confused as to what `overrideThemeStyles` function returns and had to look through the source code to figure it out.
I added a brief clarification so that it is easier for the next person.