### PR TITLE
Removed mokkapps.de from sites that use typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ NPM](https://www.npmjs.com/browse/keyword/typography-theme).
 * [React Headroom](https://kyleamathews.github.io/react-headroom/) ([source](https://github.com/KyleAMathews/react-headroom/blob/master/www/utils/typography.js))
 * [Gatsby Blog Starter](http://gatsbyjs.github.io/gatsby-starter-blog/) ([source](https://github.com/gatsbyjs/gatsby-starter-blog/blob/master/src/utils/typography.js))
 * [ollieglass.com](http://ollieglass.com/)
-* [mokkapps.de](https://www.mokkapps.de/) ([source](https://github.com/Mokkapps/website/blob/master/src/utils/typography.js))
 * [privatimkerei-hoffmann.de](https://privatimkerei-hoffmann.de/) ([source](https://github.com/Mokkapps/imkerei-hoffmann-website/blob/master/src/utils/typography.js))
 * [Rijo Joy](https://rijojoy.surge.sh/)
 * [Edit this file to add yours!](https://github.com/KyleAMathews/typography.js/blob/master/README.md)


### PR DESCRIPTION
Site does not longer use Typography.js